### PR TITLE
actions: update golang version for 1.25 release

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -5,9 +5,8 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: 1.24
+  GO_VERSION: 1.25
   CODESPELL_VERSION: v2.4.1
-
 
 jobs:
   golangci-lint:

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        golang: ['1.23', 'stable']
+        golang: ['1.23', '1.24', 'stable']
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
* now versions that are supported in gha for testing are 1.23-1.25
* running golangci-lint and checking code generation diff on latest 1.25 version